### PR TITLE
Fix broken rust link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,7 +12,7 @@ WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime.
 
 🚀 [Install](https://wasmedge.org/book/en/start/install.html) WasmEdge \
 ⌨️ Run a standalone [Wasm program](https://wasmedge.org/book/en/index.html#webassembly-examples) or a [JavaScript program](https://wasmedge.org/book/en/dev/js.html) from CLI \
-🔌 Embed a Wasm function in your [Go](https://wasmedge.org/book/en/embed/go.html), [Rust](bindings/rust/), or [C](https://wasmedge.org/book/en/embed/c.html) app \
+🔌 Embed a Wasm function in your [Go](https://wasmedge.org/book/en/embed/go.html), [Rust](https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust), or [C](https://wasmedge.org/book/en/embed/c.html) app \
 🛠 Manage and orchestrate Wasm runtimes using [Kubernetes](https://wasmedge.org/book/en/kubernetes.html), [data streaming frameworks](https://wasmedge.org/book/en/frameworks/app/yomo.html), and [blockchains](https://medium.com/ethereum-on-steroids/running-ethereum-smart-contracts-in-a-substrate-blockchain-56fbc27fc95a)
 
 ## Repository guides


### PR DESCRIPTION
Hey!
I noticed that this link was broken. It's correct in the WasmEdge repo.